### PR TITLE
fix: protect `nursery` with mutex

### DIFF
--- a/discover/table.go
+++ b/discover/table.go
@@ -190,7 +190,9 @@ func (tab *Table) setFallbackNodes(nodes []*enode.Node) error {
 			return fmt.Errorf("bad bootstrap node %q: %v", n, err)
 		}
 	}
+	tab.mutex.Lock()
 	tab.nursery = wrapNodes(nodes)
+	tab.mutex.Unlock()
 	return nil
 }
 
@@ -302,7 +304,9 @@ func (tab *Table) doRefresh(done chan struct{}) {
 
 func (tab *Table) loadSeedNodes() {
 	seeds := wrapNodes(tab.db.QuerySeeds(seedCount, seedMaxAge))
+	tab.mutex.Lock()
 	seeds = append(seeds, tab.nursery...)
+	tab.mutex.Unlock()
 	for i := range seeds {
 		seed := seeds[i]
 		age := log.Lazy{Fn: func() interface{} { return time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP())) }}


### PR DESCRIPTION
Required for https://github.com/waku-org/go-waku/issues/1059